### PR TITLE
[RFC] Teach Resolver to support request-specific scopes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     panoramic (0.0.7)
       rails (>= 4.2.0)
-      rails-controller-testing
 
 GEM
   remote: https://rubygems.org/
@@ -58,7 +57,7 @@ GEM
     diff-lcs (1.3)
     docile (1.3.0)
     erubi (1.7.1)
-    factory_girl (4.9.0)
+    factory_bot (4.11.1)
       activesupport (>= 3.0.0)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
@@ -74,10 +73,10 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mini_mime (1.0.0)
+    mini_mime (1.0.1)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    nio4r (2.3.0)
+    nio4r (2.3.1)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     rack (2.0.4)
@@ -133,7 +132,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -155,8 +154,8 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara (~> 2.5.0)
-  factory_girl
+  capybara (~> 2.5, >= 2.5.0)
+  factory_bot
   panoramic!
   rails-controller-testing
   rake
@@ -165,4 +164,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/lib/panoramic/resolver.rb
+++ b/lib/panoramic/resolver.rb
@@ -1,11 +1,26 @@
 module Panoramic
   class Resolver < ActionView::Resolver
-    require "singleton"
-    include Singleton
+    # model - Either an ActiveRecord::Relation defining the scope of templates
+    #         to be searched, or a callable object accepting a hash of details and
+    #         returning a Relation. The callable can return nil or throw the
+    #         symbol :skip_panoramic to bypass Panoramic and defer to the next
+    #         resolver.
+    #
+    # options - An optional hash of:
+    #   :only - If provided, only operate on the given prefix.
+    #
+    def initialize(model, options={})
+      super()
+      @model = model
+      @resolver_options = options
+    end
 
     # this method is mandatory to implement a Resolver
     def find_templates(name, prefix, partial, details, key=nil, locals=[])
-      return [] if @@resolver_options[:only] && !@@resolver_options[:only].include?(prefix)
+      return [] if @resolver_options[:only] && !@resolver_options[:only].include?(prefix)
+
+      request_model = resolve_model(details)
+      return [] if request_model.nil?
 
       path = build_path(name, prefix)
       conditions = {
@@ -16,20 +31,29 @@ module Panoramic
         :partial => partial || false
       }.merge(details[:additional_criteria].presence || {})
 
-      @@model.find_model_templates(conditions).map do |record|
+      request_model.find_model_templates(conditions).map do |record|
         Rails.logger.debug "Rendering template from database: #{path} (#{record.format})"
         initialize_template(record)
       end
     end
 
-    # Instantiate Resolver by passing a model (decoupled from ORMs)
-    def self.using(model, options={})
-      @@model = model
-      @@resolver_options = options
-      self.instance
+    private
+
+    def request_specific_options?
+      @model.respond_to?(:call)
     end
 
-    private
+    def resolve_model(details)
+      if request_specific_options?
+        # If the block throws :skip_panoramic, we immediately quit and fall
+        # through to the next resolver.
+        catch(:skip_panoramic) do
+          @model.call(details)
+        end
+      else
+        @model
+      end
+    end
 
     # Initialize an ActionView::Template object based on the record found.
     def initialize_template(record)

--- a/panoramic.gemspec
+++ b/panoramic.gemspec
@@ -11,12 +11,12 @@ Gem::Specification.new do |s|
   s.description = %q{A gem to store Rails views on database}
   s.license     = 'MIT'
 
-  s.add_runtime_dependency 'rails', '>= 4'
-  s.add_development_dependency 'rails-controller-testing', '~> 0'
+  s.add_runtime_dependency 'rails', '>= 4.2.0'
+  s.add_development_dependency 'rails-controller-testing'
   s.add_development_dependency 'capybara', '~> 2.5', '>= 2.5.0'
-  s.add_development_dependency 'factory_girl', '~> 0'
-  s.add_development_dependency "simplecov", '~> 0'
-  s.add_development_dependency "sqlite3", '~> 0'
+  s.add_development_dependency 'factory_bot'
+  s.add_development_dependency "simplecov"
+  s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", '~> 3.0'
 
   s.files         = `git ls-files`.split("\n")

--- a/spec/controllers/rendering_spec.rb
+++ b/spec/controllers/rendering_spec.rb
@@ -6,7 +6,7 @@ describe FooController, type: :controller do
 
   context "renders views fetched from database with" do
     it "a basic template" do
-      FactoryGirl.create(:database_template, :path => 'foo/default_layout')
+      FactoryBot.create(:database_template, :path => 'foo/default_layout')
 
       visit '/foo/default_layout'
 
@@ -15,8 +15,8 @@ describe FooController, type: :controller do
     end
 
     it "a custom layout" do
-      FactoryGirl.create(:database_template, :path => 'foo/custom_layout')
-      FactoryGirl.create(:database_template, :path => 'layouts/custom', :body => 'This is a layout with body: <%= yield %>')
+      FactoryBot.create(:database_template, :path => 'foo/custom_layout')
+      FactoryBot.create(:database_template, :path => 'layouts/custom', :body => 'This is a layout with body: <%= yield %>')
 
       visit '/foo/custom_layout'
 

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -2,8 +2,6 @@
 <html>
 <head>
   <title>Dummy</title>
-  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
 </head>
 <body>

--- a/spec/orm/active_record_spec.rb
+++ b/spec/orm/active_record_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Panoramic::Orm::ActiveRecord, type: :model do
-  let(:template) { FactoryGirl.build :database_template }
+  let(:template) { FactoryBot.build :database_template }
 
   context "validations" do
     it "has body present" do
@@ -55,7 +55,7 @@ describe Panoramic::Orm::ActiveRecord, type: :model do
       resolver = DatabaseTemplate.resolver
 
       cache_key = Object.new
-      db_template = FactoryGirl.create(:database_template, :path => 'foo/some_list', :body => 'Listing something')
+      db_template = FactoryBot.create(:database_template, :path => 'foo/some_list', :body => 'Listing something')
 
       details   = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
 

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -5,13 +5,13 @@ describe Panoramic::Resolver do
 
   context ".find_templates" do
     it "should lookup templates for given params" do
-      template = FactoryGirl.create(:database_template, :path => 'foo/example')
+      template = FactoryBot.create(:database_template, :path => 'foo/example')
       details = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
       expect(resolver.find_templates('example', 'foo', false, details).first).to_not be_nil
     end
 
     it "should lookup locale agnostic templates for given params" do
-      template = FactoryGirl.create(:database_template, :path => 'foo/example', :locale => nil)
+      template = FactoryBot.create(:database_template, :path => 'foo/example', :locale => nil)
       details = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
       expect(resolver.find_templates('example', 'foo', false, details).first).to_not be_nil
     end
@@ -20,10 +20,10 @@ describe Panoramic::Resolver do
       resolver = Panoramic::Resolver.using(DatabaseTemplate, :only => 'foo')
       details = { :formats => [:html], :locale => [:en], :handlers => [:erb] }
 
-      template = FactoryGirl.create(:database_template, :path => 'bar/example')
+      template = FactoryBot.create(:database_template, :path => 'bar/example')
       expect(resolver.find_templates('example', 'bar', false, details).first).to be_nil
 
-      template = FactoryGirl.create(:database_template, :path => 'foo/example')
+      template = FactoryBot.create(:database_template, :path => 'foo/example')
       expect(resolver.find_templates('example', 'foo', false, details).first).to_not be_nil
     end
 
@@ -31,7 +31,7 @@ describe Panoramic::Resolver do
       resolver = Panoramic::Resolver.using(DatabaseTemplate, :only => 'foo')
       details = { :formats => [:html,:text], :locale => [:en], :handlers => [:erb] }
       details[:formats].each do |format|
-        FactoryGirl.create(:database_template, :path => 'foo/example', :format => format.to_s)
+        FactoryBot.create(:database_template, :path => 'foo/example', :format => format.to_s)
       end
       templates = resolver.find_templates('example', 'foo', false, details)
       expect(templates.length).to be >= 2
@@ -60,7 +60,7 @@ describe_private Panoramic::Resolver, '(private methods)' do
   end
 
   context "#initialize_template" do
-    let(:template) { FactoryGirl.create :database_template }
+    let(:template) { FactoryBot.create :database_template }
 
     it "initializes an ActionView::Template object" do
       expect(resolver.initialize_template(template)).to be_a(ActionView::Template)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
 require "rspec/rails"
-require 'factory_girl'
+require 'factory_bot'
 
 ActionMailer::Base.delivery_method = :test
 ActionMailer::Base.perform_deliveries = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ end
 ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
-require "rails/test_help"
+# require "rails/test_help"
 require "rspec/rails"
 require 'factory_bot'
 

--- a/spec/support/factories.rb
+++ b/spec/support/factories.rb
@@ -1,11 +1,11 @@
-# FactoryGirl.define :database_template do |t|
-FactoryGirl.define do
+# FactoryBot.define :database_template do |t|
+FactoryBot.define do
   factory :database_template do
-    path    'foo/index'
-    format  'html'
-    locale  'en'
-    handler 'erb'
-    partial 'false'
-    body    "something here in the body of the page: <%= 2 + 2 %>"
+    path    { 'foo/index' }
+    format  { 'html' }
+    locale  { 'en' }
+    handler { 'erb' }
+    partial { 'false' }
+    body    { "something here in the body of the page: <%= 2 + 2 %>" }
   end
 end


### PR DESCRIPTION
This cleans up the Panoramic resolver code and expands it to support the
use case where we want to look at a different set of templates depending
on some data from each request.

The new API looks something like this:

```ruby
  # Tell ActionView what keys you'll be using in the details hash, with
  # default values. Unfortunately, for unclear reasons, ActionView
  # requires details values to be arrays.
  ActionView::LookupContext.register_detail(:color) { [] }

  class HomeController < ApplicationController
    # One resolver handles all database template requests, so it can be
    # statically inserted into the view path.
    prepend_view_path ViewTemplate.resolver

    # Inject any request-specific details based on the detail keys
    # defined above.
    def details_for_lookup
      { color: current_user.admin? ? ["red"] : ["black"] }
    end
  end

  class ViewTemplate < ActiveRecord::Base
    def self.resolver
      @resolver ||= Panoramic::Resolver.new(->(details) {
        # This lambda is run on each request, and it accepts the
        # `details` computed above in the controller.
        color = details.fetch(:color).first

        # It returns the scope to be used for this request.
        MyViewTemplateClass.where(color: color)
      })
    end
  end
```